### PR TITLE
Add support for associations with inverse_of option

### DIFF
--- a/lib/cache_depends_on/association_cache_dependency_definer.rb
+++ b/lib/cache_depends_on/association_cache_dependency_definer.rb
@@ -32,12 +32,12 @@ module CacheDependsOn
     end
 
     def find_singular_inverse_of(association)
-      suggested_singular_reverse_association_name = model_klass.model_name.singular.to_sym
+      suggested_singular_reverse_association_name = association.options.fetch(:inverse_of, model_klass.model_name.singular.to_sym)
       association.klass.reflect_on_association suggested_singular_reverse_association_name
     end
 
     def find_plural_inverse_of(association)
-      suggested_plural_reverse_association_name = model_klass.model_name.plural.to_sym
+      suggested_plural_reverse_association_name = association.options.fetch(:inverse_of, model_klass.model_name.plural.to_sym)
       association.klass.reflect_on_association suggested_plural_reverse_association_name
     end
 

--- a/spec/support/database_schema.rb
+++ b/spec/support/database_schema.rb
@@ -37,4 +37,28 @@ ActiveRecord::Schema.define version: 0 do
   create_table(:payers) do |t|
     t.timestamps null: false
   end
+
+  create_table(:companies) do |t|
+    t.timestamps null: false
+  end
+
+  create_table(:company_addresses) do |t|
+    t.belongs_to :company
+    t.timestamps null: false
+  end
+
+  create_table(:users) do |t|
+    t.belongs_to :company
+    t.timestamps null: false
+  end
+
+  create_table(:user_profiles) do |t|
+    t.belongs_to :user
+    t.timestamps null: false
+  end
+
+  create_table(:user_roles) do |t|
+    t.belongs_to :user
+    t.timestamps null: false
+  end
 end


### PR DESCRIPTION
Relations may have custom names which do not match with model class name. ActiveRecord provides `:inverse_of` option for association definition to support that.

With this PR `cache_depends_on` also starts to support associations with `:inverse_of` option